### PR TITLE
add kubeconfig flag

### DIFF
--- a/cmd/mxnet-operator.v1/app/options/options.go
+++ b/cmd/mxnet-operator.v1/app/options/options.go
@@ -43,6 +43,8 @@ func NewServerOption() *ServerOption {
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet.
 func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", "", "The path of kubeconfig file")
+
 	fs.StringVar(&s.MasterURL, "master", "",
 		`The url of the Kubernetes API server,
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)

--- a/cmd/mxnet-operator.v1beta1/app/options/options.go
+++ b/cmd/mxnet-operator.v1beta1/app/options/options.go
@@ -39,6 +39,8 @@ func NewServerOption() *ServerOption {
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet.
 func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", "", "The path of kubeconfig file")
+
 	fs.StringVar(&s.MasterURL, "master", "",
 		`The url of the Kubernetes API server,
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>
Enable defining kubeconfig path in flag.

Mirror PR: kubeflow/tf-operator#1049

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mxnet-operator/49)
<!-- Reviewable:end -->
