### PR TITLE
Add initial list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,3 +8,4 @@ This page contains a list of organizations who are using MXNet Operator. If you'
 | [Caicloud](https://caicloud.io/) | [Ce Gao](https://github.com/gaocegege) |
 | [Huawei](https://www.huawei.com/) | [Lei Su](https://github.com/suleisl2000) |
 | [Qihoo 360](https://www.360.cn/) | [Xigang Wang](https://github.com/xigang) |
+| [TuSimple](https://www.tusimple.com/) | [Hengliang He](https://github.com/henglianghe) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,10 @@
+# Adopters of MXNet Operator
+
+This page contains a list of organizations who are using MXNet Operator. If you'd like to be included here, please send a pull request which modifies this file. Please keep the list in alphabetical order.
+
+| Organization | Contact |
+| ------------ | ------- |
+| [Amazon Web Services](https://aws.amazon.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
+| [Caicloud](https://caicloud.io/) | [Ce Gao](https://github.com/gaocegege) |
+| [Huawei](https://www.huawei.com/) | [Lei Su](https://github.com/suleisl2000) |
+| [Qihoo 360](https://www.360.cn/) | [Xigang Wang](https://github.com/xigang) |


### PR DESCRIPTION
This is just an initial list of adopters. **If your company uses MXNet Operator, please let us know here.** This would help us gather use cases and collaborate with other organizations and open source communities. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>