### PR TITLE
Create separate clusterrole for mxnet-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ As an alternative solution, you can deploy mxnet-operator bypass ksonnet
 
 ```
 kubectl create -f manifests/crd-v1beta1.yaml 
-kubectl create -f manifests/rbac.yaml 
+kubectl create -f manifests/service-account.yaml
+kubectl create -f manifests/cluster-role.yaml
+kubectl create -f manifests/cluster-role-binding.yaml
 kubectl create -f manifests/deployment.yaml
 ```
 

--- a/manifests/cluster-role-binding.yaml
+++ b/manifests/cluster-role-binding.yaml
@@ -1,12 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: system-default
+  name: mxnet-operator
+  labels:
+    app: mxnet-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mxnet-operator
   namespace: default

--- a/manifests/cluster-role.yaml
+++ b/manifests/cluster-role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: mxnet-operator
+  labels:
+    app: mxnet-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - '*'

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -3,17 +3,18 @@ kind: Deployment
 metadata:
   name: mxnet-operator
   labels:
-    name: mxnet-operator
+    app: mxnet-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: mxnet-operator
+      app: mxnet-operator
   template:
     metadata:
       labels:
-        name: mxnet-operator
+        app: mxnet-operator
     spec:
+      serviceAccountName: mxnet-operator
       containers:
       - name: mxnet-operator
         image: mxjob/mxnet-operator:v1beta1

--- a/manifests/service-account.yaml
+++ b/manifests/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mxnet-operator
+  labels:
+    app: mxnet-operator


### PR DESCRIPTION
Resolves #65. 

This actually syncs some changes from my previous change in `kubeflow/manifest` https://github.com/kubeflow/manifests/pull/279. standalone manifest and kubeflow manifest will be consistent now.

Instead of using ClusterAdmin, we ceate a separate role `mxnet-operator` to fine grain control the permissions mxnet-operator needs.

We will use similar manifest in `kubeflow/manifest`.

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>