### PR TITLE
Remove Travis buddy webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,3 @@ script:
   # to match ignore files and it does not support it.
   - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*.go,pkg/client/*/*/*.go,pkg/client/*/*/*/*.go,pkg/client/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*/*.go,pkg/apis/mxnet/*/zz_generated.*.go"
 
-notifications:
-  on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,4 @@ script:
   - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*.go,pkg/client/*/*/*.go,pkg/client/*/*/*/*.go,pkg/client/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*/*.go,pkg/apis/mxnet/*/zz_generated.*.go"
 
 notifications:
-  webhooks: https://www.travisbuddy.com/
   on_success: never


### PR DESCRIPTION
Removing this since the comments generated by Travis buddy is very verbose and not useful.