### PR TITLE
Support 1.16 - Upgrade deployment apiversion to apps/v1

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mxnet-operator


### PR DESCRIPTION
`extensions/v1beta1` has been deprecated and MXNet operator can not be deployed on 1.16 cluster. 

This PR help upgrade the api versions and fix the issue