### PR TITLE
Support BytePS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Overview
 
 MXNet Operator provides a Kubernetes custom resource `MXJob` that makes it easy to
-run distributed or non-distributed [Apache MXNet](https://github.com/apache/incubator-mxnet) jobs (training and tuning) on Kubernetes. 
+run distributed or non-distributed [Apache MXNet](https://github.com/apache/incubator-mxnet) jobs (training and tuning) 
+and other extended framework like [BytePS](https://github.com/bytedance/byteps) jobs on Kubernetes. 
 Using a Custom Resource Definition (CRD) gives users the ability to create 
 and manage Apache MXNet jobs just like built-in K8S resources. 
 

--- a/pkg/controller.v1beta1/mxnet/pod.go
+++ b/pkg/controller.v1beta1/mxnet/pod.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
@@ -248,6 +248,14 @@ func setClusterSpec(podTemplateSpec *v1.PodTemplateSpec, mxjob *mxv1beta1.MXJob,
 			Name:  "DMLC_USE_KUBERNETES",
 			Value: strconv.Itoa(1),
 		})
+
+		// BytePS needs env DMLC_WORKER_ID for each worker
+		if rt == strings.ToLower(string(mxv1beta1.MXReplicaTypeWorker)) {
+			c.Env = append(c.Env, v1.EnvVar{
+				Name:  "DMLC_WORKER_ID",
+				Value: index,
+			})
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
BytePS is a high performance and generic framework for distributed DNN training. For a successful start, it needs scheduler, server and worker, which is similar to MXNet. 

After a short discussion with @suleisl2000 , we both agreed it would be OK to launch BytePS job using mxnet-operator. This minor change would only inject env `DMLC_WORKER_ID` to each worker, while others remain unchanged. 