### PR TITLE
Allow mxnet-operator to read/update status of mxjob

### DIFF
--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -9,6 +9,7 @@ rules:
   - kubeflow.org
   resources:
   - mxjobs
+  - mxjobs/status
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
The clusterrole provided for mxnet operator is missing the permission for mxjobs/status resource.
So when mxnet-operator tries updating the job status, a forbidden error will occur.